### PR TITLE
Fix scanning repositories

### DIFF
--- a/package/usr/share/gitaptly/scan
+++ b/package/usr/share/gitaptly/scan
@@ -9,7 +9,7 @@ fi
 per_page=100
 host=api.github.com
 path="/repos/$1/releases?per_page=$per_page"
-printf "HEAD $path HTTP/1.1\r\nConnection: close\r\nUser-Agent: gitaptly\r\nHost: $host\r\n$auth_header\r\n\r\n" | ncat --ssl --no-shutdown "$host" 443 \
+printf "HEAD $path HTTP/1.1\r\nConnection: close\r\nUser-Agent: gitaptly\r\nHost: $host\r\n$auth_header\r\n\r\n" | ncat --ssl --no-shutdown "$host" 443 | tr '[:upper:]' '[:lower:]' \
   | grep '^link: ' | cut -d ' '  -f 2- | tr -d ' <>' | tr ',' '\n' \
   | grep 'rel="last"' | cut -d ';' -f1 | cut -d '?' -f 2- | tr '&' '\n' \
   | grep '^page=' | cut -d = -f 2 \

--- a/package/usr/share/gitaptly/scan
+++ b/package/usr/share/gitaptly/scan
@@ -11,7 +11,7 @@ host=api.github.com
 path="/repos/$1/releases?per_page=$per_page"
 printf "HEAD $path HTTP/1.1\r\nConnection: close\r\nUser-Agent: gitaptly\r\nHost: $host\r\n$auth_header\r\n\r\n" | ncat --ssl --no-shutdown "$host" 443 | tr '[:upper:]' '[:lower:]' \
   | grep '^link: ' | cut -d ' '  -f 2- | tr -d ' <>' | tr ',' '\n' \
-  | grep 'rel="last"' | cut -d ';' -f1 | cut -d '?' -f 2- | tr '&' '\n' \
+  | grep 'rel="last"' | cut -d ';' -f 1 | cut -d '?' -f 2- | tr '&' '\n' \
   | grep '^page=' | cut -d = -f 2 \
   | xargs seq 1 | xargs parallel -q curl --no-progress-meter --fail --retry 16 --retry-all-errors -H "$auth_header" https://"$host""$path"\&page={} ::: \
   | jq '.[] | .assets[] | .browser_download_url' -r | (grep '.deb$' || true)


### PR DESCRIPTION
changing the first HEAD request to netcat, caused the header names to be fully lowercase because they dont get processed and normalized by curl anymore. so we just force them all to lowercase so that the following code will work again